### PR TITLE
include information about automation-examples repo

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -20,10 +20,11 @@ To subscribe a system to the IUS repository, you need to install the
 ius-release RPM.  Please note that ius-release depends on epel-release, because
 several IUS packages have dependencies from EPEL.
 
-## Scripted Install
+## Install via Automation
 
-A short bash script is available at [setup.ius.io][3] that automatically
-handles installation of both epel-release and ius-release.
+Automation examples are available at the [automation-examples github
+repository][3].  We also have the bash script from that repository available at
+[setup.ius.io][4].
 
 ## Manual Install
 
@@ -33,35 +34,36 @@ If you are using CentOS, you can skip this step.  The epel-release package is
 available from the CentOS Extras repository (enabled by default) and will be
 pulled in as a dependency of ius-release automatically.
 
-RHEL users must follow the [EPEL documentation][4] and use one of the following
+RHEL users must follow the [EPEL documentation][5] and use one of the following
 links to get the correct release package.
 
-* [https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm][5]
-* [https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm][6]
-* [https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm][7]
+* [https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm][6]
+* [https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm][7]
+* [https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm][8]
 
 ### ius-release
 
 IUS compiles seperate packages for RHEL and CentOS.  Use one of the following
 links to get the correct release package.
 
-* [https://rhel5.iuscommunity.org/ius-release.rpm][8]
-* [https://rhel6.iuscommunity.org/ius-release.rpm][9]
-* [https://rhel7.iuscommunity.org/ius-release.rpm][10]
-* [https://centos5.iuscommunity.org/ius-release.rpm][11]
-* [https://centos6.iuscommunity.org/ius-release.rpm][12]
-* [https://centos7.iuscommunity.org/ius-release.rpm][13]
+* [https://rhel5.iuscommunity.org/ius-release.rpm][9]
+* [https://rhel6.iuscommunity.org/ius-release.rpm][10]
+* [https://rhel7.iuscommunity.org/ius-release.rpm][11]
+* [https://centos5.iuscommunity.org/ius-release.rpm][12]
+* [https://centos6.iuscommunity.org/ius-release.rpm][13]
+* [https://centos7.iuscommunity.org/ius-release.rpm][14]
 
 [1]: https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-EUA
 [2]: Usage.md
-[3]: https://setup.ius.io
-[4]: https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F
-[5]: https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
-[6]: https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
-[7]: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-[8]: https://rhel5.iuscommunity.org/ius-release.rpm
-[9]: https://rhel6.iuscommunity.org/ius-release.rpm
-[10]: https://rhel7.iuscommunity.org/ius-release.rpm
-[11]: https://centos5.iuscommunity.org/ius-release.rpm
-[12]: https://centos6.iuscommunity.org/ius-release.rpm
-[13]: https://centos7.iuscommunity.org/ius-release.rpm
+[3]: https://github.com/iuscommunity/automation-examples
+[4]: https://setup.ius.io/
+[5]: https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F
+[6]: https://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm
+[7]: https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+[8]: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+[9]: https://rhel5.iuscommunity.org/ius-release.rpm
+[10]: https://rhel6.iuscommunity.org/ius-release.rpm
+[11]: https://rhel7.iuscommunity.org/ius-release.rpm
+[12]: https://centos5.iuscommunity.org/ius-release.rpm
+[13]: https://centos6.iuscommunity.org/ius-release.rpm
+[14]: https://centos7.iuscommunity.org/ius-release.rpm


### PR DESCRIPTION
We should include information about the automation-examples repo in the getting started page.  
