### PR TITLE
change from LaunchPad mailing lists to GitHub announce repository

### DIFF
--- a/docs/History.md
+++ b/docs/History.md
@@ -50,8 +50,8 @@ it and recommend all users switch back to the stock OpenSSL packages.
 
 When the IUS project first started, [LaunchPad][9] was the best location for
 version control, bugs and mailing lists. Unfortunately, LaunchPad is starting
-to show its age and thus we switched to GitHub for version control and
-bugs/issues. We still use LaunchPad for our mailing lists.
+to show its age and thus we switched to GitHub for version control,
+announcements, and bugs/issues.
 
 
 [1]: https://www.rackspace.com

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,13 +25,9 @@ Most of our development is done in [GitHub][4], so that is the best way to
 reach us.  Our package sources can be found in the [iuscommunity-pkg][5]
 organization; issues for specific packages should be reported here.  We also
 have the [iuscommunity][6] organization for everything else, such as [the
-source for this website][7] and our [new package wishlist][8].
-
-Other contact methods:
-
-* `#iuscommunity` on [freenode][9]
-* [general mailing list][10]
-* [development mailing list][11]
+source for this website][7], [important announcements][8](like an announce
+mailing list), and our [new package wishlist][9].  We can also be found in
+`#iuscommunity` on [freenode][10].
 
 [1]: Philosophy.md
 [2]: GettingStarted.md
@@ -40,7 +36,6 @@ Other contact methods:
 [5]: https://github.com/iuscommunity-pkg
 [6]: https://github.com/iuscommunity
 [7]: https://github.com/iuscommunity/ius.io
-[8]: https://github.com/iuscommunity/wishlist
-[9]: https://freenode.net
-[10]: https://launchpad.net/~ius-community
-[11]: https://launchpad.net/~ius-coredev
+[8]: https://github.com/iuscommunity/announce
+[9]: https://github.com/iuscommunity/wishlist
+[10]: https://freenode.net

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,9 +25,9 @@ Most of our development is done in [GitHub][4], so that is the best way to
 reach us.  Our package sources can be found in the [iuscommunity-pkg][5]
 organization; issues for specific packages should be reported here.  We also
 have the [iuscommunity][6] organization for everything else, such as [the
-source for this website][7], [important announcements][8](like an announce
-mailing list), and our [new package wishlist][9].  We can also be found in
-`#iuscommunity` on [freenode][10].
+source for this website][7], [announcement notifications][8], and our [new
+package wishlist][9].  We can also be found in `#iuscommunity` on
+[freenode][10].
 
 [1]: Philosophy.md
 [2]: GettingStarted.md


### PR DESCRIPTION
Fairly minimal changes to reflect mailing list going away and new GitHub announce repository.
